### PR TITLE
アカウント有効化処理・エンドポイントの追加

### DIFF
--- a/server/app/accounts/urls.py
+++ b/server/app/accounts/urls.py
@@ -2,11 +2,18 @@
 
 from django.urls import path
 
-from .views import JWTokenObtainView, JWTokenRefreshView, LogoutView, UserListAPIView
+from .views import (
+    JWTokenObtainView,
+    JWTokenRefreshView,
+    LogoutView,
+    UserListAPIView,
+    user_activation_view,
+)
 
 urlpatterns = [
     path("users/", UserListAPIView.as_view()),
     path("auth/jwt/create/", JWTokenObtainView.as_view()),
     path("auth/jwt/refresh/", JWTokenRefreshView.as_view()),
     path("auth/logout/", LogoutView.as_view()),
+    path("auth/user/activate/<str:uid>/<str:token>/", user_activation_view),
 ]

--- a/server/app/accounts/views.py
+++ b/server/app/accounts/views.py
@@ -1,3 +1,4 @@
+import requests
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
@@ -114,3 +115,15 @@ def get_csrf_token(request):
     # CSRFトークンをHTTPOnlyのクッキーにセット
     response.set_cookie("csrftoken", csrf_token, httponly=True)
     return response
+
+
+def user_activation_view(request, uid, token):
+    post_url = request.build_absolute_uri("/api/auth/users/activation/")
+    data = {
+        "uid": uid,
+        "token": token,
+    }
+    response = requests.post(post_url, json=data)
+    if response.status_code == 204:
+        return HttpResponse("アカウント有効化成功")
+    return HttpResponse("アカウント有効化失敗")

--- a/server/app/config/settings/base.py
+++ b/server/app/config/settings/base.py
@@ -208,11 +208,11 @@ DJOSER = {
     # パスワード変更時に確認用パスワード必須
     "SET_PASSWORD_RETYPE": True,
     # アカウント本登録用URL
-    "ACTIVATION_URL": "#/activate/{uid}/{token}",
+    "ACTIVATION_URL": "api/auth/user/activate/{uid}/{token}/",
     # メールアドレスリセット完了用URL
-    "USERNAME_RESET_CONFIRM_URL": "email/reset/confirm/{uid}/{token}",
+    "USERNAME_RESET_CONFIRM_URL": "email/reset/confirm/{uid}/{token}/",
     # パスワードリセット完了用URL
-    "PASSWORD_RESET_CONFIRM_URL": "password/reset/confirm/{uid}/{token}",
+    "PASSWORD_RESET_CONFIRM_URL": "password/reset/confirm/{uid}/{token}/",
     # カスタムユーザー用シリアライザー
     "SERIALIZERS": {
         "user_create": "accounts.serializers.UserSerializer",

--- a/server/app/config/urls.py
+++ b/server/app/config/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
-
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("campuses.urls")),


### PR DESCRIPTION
### 詳細
- `/api/auth/user/activate/{uid}/{token}/`のエンドポイント作成
- viewの作成
　- urlからuid・tokenを取得し、それらのデータを`api/auth/users/activation/`にpostしなおす処理を記述
- メール添付のURLの更新

### 課題
- 成功時のレスポンスとして何を返すか
　一旦、「有効化成功」か「有効化失敗」を返すように実装。
　フロントのエンドポイントがあるのであればリダイレクトする手もあるが、バックエンドとしては処理だけを担い、レスポンス内容によってフロントで
有効化が成功している際はログイン画面にリダイレクト、
していない時は、再度有効化メールを送り直すurlを含むエラー画面を表示
のような形をとるといいのではないか？