### PR TITLE
listing_statusでのソートを実装

### DIFF
--- a/server/app/items/views.py
+++ b/server/app/items/views.py
@@ -13,8 +13,11 @@ class ItemListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         queryset = Item.objects.all()
         name_query = self.request.query_params.get("name", None)
+        listing_status_query = self.request.query_params.get("listing_status", None)
         if name_query:
             queryset = queryset.filter(name__icontains=name_query)
+        if listing_status_query:
+            queryset = queryset.filter(listing_status=listing_status_query)
         return queryset
 
 


### PR DESCRIPTION
# 実装内容
- listing_statusというクエリで未購入/購入済み/完了などのステータスでソートできるようにしました。

# 動作確認
## アプリ
https://github.com/cat-katsushika/project1/assets/82959924/e42ac102-e0db-4231-aeef-c3006fa5cbde

## サーバー
```
[26/Sep/2023 23:31:02] "GET /api/items/?name=&user=&page=2&listing_status=unpurchased HTTP/1.1" 200 1539
[26/Sep/2023 23:31:02] "GET /api/items/?name=&user=&page=3&listing_status= HTTP/1.1" 200 2056
```

# レビューしていただきたい内容
- 一応動くと思いますが、設計等で問題があれば修正お願いします。