### PR TITLE
VSCodeのアップデート対応

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   // vscode
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
   "editor.formatOnSave": true,
   "files.eol": "\n",


### PR DESCRIPTION
VSCodeのアップデートで勝手に変更されてしまうので、このコミットで変更しておきます。
参考: https://zenn.dev/braveryk7/articles/source-fixall-eslint-value